### PR TITLE
Update fraction.js for Chrome 35

### DIFF
--- a/fraction.js
+++ b/fraction.js
@@ -92,7 +92,10 @@ Fraction = function(numerator, denominator)
         } else if (typeof(num) === 'string') {
             var a, b;  // hold the first and second part of the fraction, e.g. a = '1' and b = '2/3' in 1 2/3
                        // or a = '2/3' and b = undefined if we are just passed a single-part number
-            [a, b] = num.split(' ');
+                       
+            var t = num.split(' ');
+            a = t[0], b = t[1];
+            
             /* compound fraction e.g. 'A B/C' */
             //  if a is an integer ...
             if (a % 1 === 0 && b && b.match('/')) {


### PR DESCRIPTION
Line 95
 [a, b] = num.split(' '); Give an error on Chrome 35 : 
Array must be explicitly assign.
