### PR TITLE
Fix negative value bug

### DIFF
--- a/fraction.js
+++ b/fraction.js
@@ -136,7 +136,7 @@ Fraction.prototype.toString = function()
     if (wholepart != 0) 
         result.push(wholepart);
     if (numerator != 0)  
-        result.push(numerator + '/' + denominator);
+        result.push(Math.abs(numerator) + '/' + denominator);
     return result.length > 0 ? result.join(' ') : 0;
 }
 


### PR DESCRIPTION
In the toString method, if there is a negative value, it's displayed like this: -2 -1/4. This makes it displayed like this: -2 1/4
